### PR TITLE
multiple notebook fixes

### DIFF
--- a/src/core/components/notebook/NotebookCell.js
+++ b/src/core/components/notebook/NotebookCell.js
@@ -55,7 +55,6 @@ class NotebookCell extends React.Component {
         isNewNext: PropTypes.bool.isRequired,
         isNewPrevious: PropTypes.bool.isRequired,
         notebook: PropTypes.object.isRequired,
-        isFirstCell:PropTypes.bool,
         onAddFilteredCommand: PropTypes.func.isRequired,
         onCancelExec: PropTypes.func,
         onCheckStatus: PropTypes.func,
@@ -71,7 +70,9 @@ class NotebookCell extends React.Component {
         onSelect: PropTypes.func.isRequired,
         onSubmitCell: PropTypes.func,
         userSettings: PropTypes.object.isRequired,
-        onEditSpreadsheet: PropTypes.func.isRequired
+        onEditSpreadsheet: PropTypes.func.isRequired,
+        onRecommendAction: PropTypes.func.isRequired,
+        onResetRecommendations: PropTypes.func.isRequired
     }
     /**
      * Add the command that is associated with this notebook cell module
@@ -147,6 +148,13 @@ class NotebookCell extends React.Component {
             onSelect(cell);
         }
     }
+    /**
+     * Handle new cell recommendations
+     */
+    handleRecommendAction = (packageId, commandId) => {
+        const { cell, onRecommendAction } = this.props;
+        onRecommendAction(packageId, commandId, cell);
+    }
     render() {
         const {
             apiEngine,
@@ -165,7 +173,7 @@ class NotebookCell extends React.Component {
             onSubmitCell,
             userSettings,
             onEditSpreadsheet,
-            isFirstCell
+            onResetRecommendations
         } = this.props;
         // The main components of a notebook cell are the cell index, the cell
         // dropdown menu, the cell command text or input form and the cell
@@ -185,18 +193,18 @@ class NotebookCell extends React.Component {
             // know which (and how many) cells are still executing.
             const cmdSpec = cell.commandSpec;
             if ((!cell.isActive()) && (userSettings.isFiltered(cmdSpec))) {
-            	let errorcss = '';
-            	let errorIcon = null;
+                let errorcss = '';
+                let errorIcon = null;
                 if (cell.isErrorOrCanceled()) {
-                	errorcss = ' collapsed-error-cell';
-                	if (cell.isCanceled()) {
-                		errorIcon = (<Icon name='cancel' color='red' title='Canceled'/>);
+                    errorcss = ' collapsed-error-cell';
+                    if (cell.isCanceled()) {
+                        errorIcon = (<Icon name='cancel' color='red' title='Canceled'/>);
                     } else if (cell.isError()) {
-                    	errorIcon = (<Icon name='warning circle' color='red' title='Error' />);
+                        errorIcon = (<Icon name='warning circle' color='red' title='Error' />);
                     }
-                	
+
                 }
-            	if (!userSettings.hideFilteredCommands()) {
+                if (!userSettings.hideFilteredCommands()) {
                     return (
                         <div className={'horizontal-divider' + errorcss} >
                             { errorIcon }
@@ -249,6 +257,8 @@ class NotebookCell extends React.Component {
                     onSelectCell={this.handleSelectCell}
                     userSettings={userSettings}
                     onEditSpreadsheet={onEditSpreadsheet}
+                    onRecommendAction={this.handleRecommendAction}
+                    apiEngine={apiEngine}
                 />
             );
         }
@@ -258,12 +268,12 @@ class NotebookCell extends React.Component {
                 datasets={datasets}
                 cell={cell}
                 isActiveCell={(isActiveCell) && (!notebook.readOnly)}
-                isFirstCell={isFirstCell}
                 onClick={this.handleSelectCell}
                 onDismiss={onDismissCell}
                 onSelectCell={this.handleSelectCell}
                 onSubmit={onSubmitCell}
                 userSettings={userSettings}
+                onResetRecommendations={onResetRecommendations}
             />
         );
         // The CSS class depends on whether the cell is active or not and
@@ -280,16 +290,16 @@ class NotebookCell extends React.Component {
         }
         return (
             <table className={css + cssState}><tbody>
-                <tr>
-                    <td className={'cell-index' + cssState} onClick={this.handleSelectCell}>
-                        <p className={'cell-index' + cssState}>[{cellIndex}]</p>
-                        { cellMenu }
-                    </td>
-                    <td className={'cell-area' + cssState}>
-                        { commandText }
-                        { outputArea }
-                    </td>
-                </tr>
+            <tr>
+                <td className={'cell-index' + cssState} onClick={this.handleSelectCell}>
+                    <p className={'cell-index' + cssState}>[{cellIndex}]</p>
+                    { cellMenu }
+                </td>
+                <td className={'cell-area' + cssState}>
+                    { commandText }
+                    { outputArea }
+                </td>
+            </tr>
             </tbody></table>
         );
     }

--- a/src/core/components/notebook/input/CellCommandArea.js
+++ b/src/core/components/notebook/input/CellCommandArea.js
@@ -51,7 +51,7 @@ class CellCommandArea extends React.Component {
         onSelectCell: PropTypes.func.isRequired,
         onSubmit: PropTypes.func,
         userSettings: PropTypes.object.isRequired,
-        isFirstCell: PropTypes.bool
+        onResetRecommendations: PropTypes.func
     }
     constructor(props) {
         super(props);
@@ -228,11 +228,13 @@ class CellCommandArea extends React.Component {
      */
     handleDismissCommandsListing = () => {
         const { selectedCommand } = this.state;
+        const { onResetRecommendations } = this.props;
         if (selectedCommand != null) {
             this.setState({showCommandsListing: false});
         } else {
             this.handleDismiss();
         }
+        onResetRecommendations()
     }
     /**
      * Clear the list of error messages.
@@ -244,7 +246,7 @@ class CellCommandArea extends React.Component {
      * Set the command in the user settings clipboard as the selected command.
      */
     handlePasteCommand = () => {
-        const { datasets, userSettings } = this.props;
+        const { datasets, userSettings, onResetRecommendations} = this.props;
         this.setState({
             formValues: toFormValues(
                 userSettings.clipboard.commandSpec.parameters,
@@ -254,19 +256,21 @@ class CellCommandArea extends React.Component {
             selectedCommand: userSettings.clipboard.commandSpec,
             showCommandsListing: false
         });
+        onResetRecommendations()
     }
     /**
      * Update the selected command to the command that is identified by the
      * given pair of package and command identifier.
      */
     handleSelectCommand = (packageId, commandId) => {
-        const { apiEngine, datasets } = this.props;
+        const { apiEngine, datasets, onResetRecommendations} = this.props;
         const cmd = apiEngine.packages.getCommandSpec(packageId, commandId);
         this.setState({
             formValues: toFormValues(cmd.parameters, datasets),
             selectedCommand: cmd,
             showCommandsListing: false
         });
+        onResetRecommendations()
     }
     /**
      * Set the showCommandsListing to true to show a list of available commands.
@@ -345,7 +349,6 @@ class CellCommandArea extends React.Component {
             onClick,
             onSubmit,
             userSettings,
-            isFirstCell
         } = this.props;
         const {
             errors,
@@ -385,7 +388,6 @@ class CellCommandArea extends React.Component {
             mainContent = (
                 <CommandsListing
                     apiEngine={apiEngine}
-                    isFirstCell={isFirstCell}
                     onDismiss={this.handleDismissCommandsListing}
                     onPaste={onPaste}
                     onSelect={this.handleSelectCommand} />

--- a/src/core/components/notebook/input/CommandsListing.js
+++ b/src/core/components/notebook/input/CommandsListing.js
@@ -32,7 +32,6 @@ class CommandsListing extends React.Component {
         onDismiss: PropTypes.func.isRequired,
         onPaste: PropTypes.func,
         onSelect: PropTypes.func.isRequired,
-        isFirstCell:PropTypes.bool
     }
     
     groupBy = (arr, property)  => {
@@ -45,7 +44,7 @@ class CommandsListing extends React.Component {
 
     	
     render() {
-        const { apiEngine, onDismiss, onPaste, onSelect, isFirstCell} = this.props;
+        const { apiEngine, onDismiss, onPaste, onSelect} = this.props;
         // Get a list of command types
         const gridColumns = [];
         // Get list of packages. The list is sorted by package name by default.
@@ -69,7 +68,7 @@ class CommandsListing extends React.Component {
 	            );
 	            for (let i = 0; i < commands.length; i++) {
 	                const cmd = commands[i];
-                    let item = isFirstCell && cmd.suggest ? <List.Item key={listItems.length} onClick={() => (onSelect(pckg.id, cmd.id))}>
+                    let item = cmd.suggest ? <List.Item key={listItems.length} onClick={() => (onSelect(pckg.id, cmd.id))}>
                         <List.Content>
                             <List.Header as='a' className='suggested-action' icon>
                                 <Header.Content>

--- a/src/core/components/notebook/output/CellOutputArea.js
+++ b/src/core/components/notebook/output/CellOutputArea.js
@@ -47,6 +47,7 @@ import { isCellOutputRequest } from '../../../actions/project/Notebook';
 class CellOutputArea extends React.Component {
     static propTypes = {
         cell: PropTypes.object.isRequired,
+        datasets: PropTypes.object.isRequired,
         onCancelExec: PropTypes.func,
         onCheckStatus: PropTypes.func,
         onFetchAnnotations: PropTypes.func.isRequired,
@@ -54,7 +55,9 @@ class CellOutputArea extends React.Component {
         onOutputSelect: PropTypes.func.isRequired,
         onSelectCell: PropTypes.func.isRequired,
         userSettings: PropTypes.object.isRequired,
-        onEditSpreadsheet: PropTypes.func.isRequired
+        onEditSpreadsheet: PropTypes.func.isRequired,
+        onRecommendAction: PropTypes.func.isRequired,
+        apiEngine: PropTypes.object.isRequired
     };
     state = {
         activeTab: null,
@@ -255,7 +258,12 @@ class CellOutputArea extends React.Component {
      * Returns a dataset view
      */
     getDatasetView = (id, dataset) => {
-        const {onSelectCell, onNavigateDataset, userSettings, onEditSpreadsheet} = this.props;
+        const {onSelectCell, datasets, onNavigateDataset, userSettings, onEditSpreadsheet, onRecommendAction, apiEngine} = this.props;
+        try {
+            dataset.name = datasets[dataset.id].name;
+        }catch (TypeError) {
+            // prevent breakage
+        }
         return (
             <div className='output-content'>
                 <DatasetView
@@ -266,6 +274,8 @@ class CellOutputArea extends React.Component {
                     userSettings={userSettings}
                     onEditSpreadsheet={onEditSpreadsheet}
                     moduleId={id}
+                    downloadLimit={apiEngine.serviceProperties.maxDownloadRowLimit}
+                    onRecommendAction={onRecommendAction}
                 />
             </div>
         )

--- a/src/core/components/spreadsheet/DatasetView.js
+++ b/src/core/components/spreadsheet/DatasetView.js
@@ -45,7 +45,8 @@ class DatasetView extends React.Component {
         onSelectCell: PropTypes.func.isRequired,
         userSettings: PropTypes.object.isRequired,
         onEditSpreadsheet: PropTypes.func.isRequired,
-        moduleId: PropTypes.string.isRequired
+        downloadLimit: PropTypes.number.isRequired,
+        onRecommendAction: PropTypes.func.isRequired
     }
     constructor(props) {
         super(props);
@@ -88,7 +89,7 @@ class DatasetView extends React.Component {
     }
     
     render() {
-        const { dataset, onFetchAnnotations, onNavigate, onSelectCell, userSettings, onEditSpreadsheet, moduleId } = this.props;
+        const { dataset, onFetchAnnotations, onNavigate, onSelectCell, userSettings, onEditSpreadsheet, moduleId, downloadLimit, onRecommendAction } = this.props;
         const activeCell = this.state;
         // Content header
         const contentHeader = (
@@ -100,7 +101,10 @@ class DatasetView extends React.Component {
                 <SpreadsheetDropDown 
                 	dataset={dataset}
                     onEditSpreadsheet={onEditSpreadsheet}
-                    moduleId={moduleId} />
+                    moduleId={moduleId}
+                    downloadLimit={downloadLimit}
+                    onRecommendAction={onRecommendAction}
+                />
             </div>
         );
 

--- a/src/core/components/spreadsheet/DatasetView.js
+++ b/src/core/components/spreadsheet/DatasetView.js
@@ -46,7 +46,7 @@ class DatasetView extends React.Component {
         userSettings: PropTypes.object.isRequired,
         onEditSpreadsheet: PropTypes.func.isRequired,
         downloadLimit: PropTypes.number.isRequired,
-        onRecommendAction: PropTypes.func.isRequired
+        onRecommendAction: PropTypes.func
     }
     constructor(props) {
         super(props);

--- a/src/core/components/spreadsheet/menu/SpreadsheetDropDown.js
+++ b/src/core/components/spreadsheet/menu/SpreadsheetDropDown.js
@@ -18,7 +18,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Confirm, Dropdown} from 'semantic-ui-react'
+import { Header, Button, Popup, Grid, Dropdown, Icon, GridColumn } from 'semantic-ui-react'
 import { HATEOAS_DATASET_DOWNLOAD } from '../../../util/HATEOAS'
 
 /**
@@ -33,15 +33,6 @@ class SpreadsheetDropDown extends React.Component {
         moduleId: PropTypes.string.isRequired,
         downloadLimit: PropTypes.number.isRequired,
         onRecommendAction: PropTypes.func
-    }
-
-    state = { open: false }
-    handleShow = () => this.setState({ open: true })
-    handleCancel = () => this.setState({ open: false })
-    onConfirm = () => {
-        const { onRecommendAction } = this.props;
-        this.setState({ open: false });
-        onRecommendAction('data','unload');
     }
 
     /**
@@ -59,63 +50,69 @@ class SpreadsheetDropDown extends React.Component {
     }
     /**
      * Open a new window with the dataset URL to download the data in CSV
-     * format if row count less than preset value. If not, recommend the UNLOAD DATASET cell
+     * format if row count less than the allowed value. If not, recommend the UNLOAD DATASET cell
      */
     handleDownload = () => {
-        const { dataset, downloadLimit, onRecommendAction } = this.props;
+        const { dataset, downloadLimit } = this.props;
         if (dataset.rowCount <= downloadLimit){
             const downloadUrl = dataset.links.get(HATEOAS_DATASET_DOWNLOAD)
             window.open(downloadUrl);
-        }else {
-            // this.handleShow()
-            onRecommendAction('data','unload');
         }
     };
+    /**
+     * Handles the edit spreadsheet selection
+     */
     handleEditSpreadsheet = () => {
-        const { dataset, onEditSpreadsheet, moduleId } = this.props
+        const { dataset, onEditSpreadsheet, moduleId } = this.props;
         onEditSpreadsheet(dataset, moduleId)
     }
     render() {
-        const {downloadLimit} = this.props
-        const unloadDatasetModal =
-            <Confirm
-                content={'The dataset exceeds the allowed limit of ' + downloadLimit + ' rows. It is recommended to export large datasets using the Unload Cell.'}
-                open={this.state.open}
-                cancelButton={'Cancel'}
-                confirmButton={'Unload Dataset'}
-                onCancel={this.handleCancel}
-                onConfirm={this.onConfirm}
-            />
-        return (
-            <React.Fragment>
-                { unloadDatasetModal }
-                <Dropdown icon='download' title='Download dataset'>
-                    <Dropdown.Menu>
-                        <Dropdown.Item
-                            key={'download'}
-                            icon='download'
-                            text='Download File'
-                            title='Download dataset as CSV file'
-                            onClick={this.handleDownload}
-                        />
-                        <Dropdown.Item
-                            key={'copy-link'}
-                            icon='linkify'
-                            text='Copy URL to Clipboard'
-                            title='Copy shareable dataset URL to clipboard'
-                            onClick={this.handleCopy}
-                        />
-                        <Dropdown.Item
-                            key={'edit'}
-                            icon='edit'
-                            text='Edit as Spreadsheet'
-                            title='Open spreadsheet view to edit the dataset'
-                            onClick={this.handleEditSpreadsheet}
-                        />
-                    </Dropdown.Menu>
-                </Dropdown>
-            </React.Fragment>
-        );
+        const { dataset, downloadLimit, onRecommendAction } = this.props;
+        let downloadDropdown = <Popup trigger={<Dropdown.Item
+            key={'download'}
+            icon='download'
+            text='Download File'
+            title='Download dataset as CSV file'
+            onClick={this.handleDownload}
+        />}
+                                      on='click'
+                                      disabled = {dataset.rowCount <= downloadLimit}
+                                      hoverable
+                                      basic>
+            <Grid centered>
+                <GridColumn textAlign='center'>
+                    <Header as='h4' icon textAlign='center'>
+                        <Icon name='times circle' />
+                    </Header>
+                    <p>
+                        {'The dataset exceeds the allowed limit of ' + downloadLimit + ' rows. It is recommended to export large datasets using the Unload Cell.'}
+                    </p>
+                    <Button color='blue' content='Unload' onClick={() => onRecommendAction('data','unload')} />
+                </GridColumn>
+            </Grid>
+        </Popup>;
+
+        return <React.Fragment>
+            <Dropdown icon='download' title='Download dataset'>
+                <Dropdown.Menu>
+                    {downloadDropdown}
+                    <Dropdown.Item
+                        key={'copy-link'}
+                        icon='linkify'
+                        text='Copy URL to Clipboard'
+                        title='Copy shareable dataset URL to clipboard'
+                        onClick={this.handleCopy}
+                    />
+                    <Dropdown.Item
+                        key={'edit'}
+                        icon='edit'
+                        text='Edit as Spreadsheet'
+                        title='Open spreadsheet view to edit the dataset'
+                        onClick={this.handleEditSpreadsheet}
+                    />
+                </Dropdown.Menu>
+            </Dropdown>
+        </React.Fragment>
     }
 }
 

--- a/src/core/containers/project/NotebookPage.js
+++ b/src/core/containers/project/NotebookPage.js
@@ -386,12 +386,9 @@ class NotebookPage extends Component {
      * Switch to spreadsheet view and load the selected dataset for module.
      */
     handleEditSpreadsheet = (dataset, moduleId) => {
-        const { dispatch, history, branch } = this.props;
-        const downloadUrl = dataset.links.get(HATEOAS_DATASET_DOWNLOAD)
-        const regexp = /projects\/([a-z0-9]+)\/datasets\/([a-z0-9]+)/g;
-        const matches = Array.from(downloadUrl.matchAll(regexp));
-        const projectId = matches[0][1];
-        const datasetId = matches[0][2];
+        const { dispatch, history, branch, project } = this.props;
+        const projectId = project.id;
+        const datasetId = dataset.id;
         dispatch(showModuleSpreadsheet(dataset, 0, 25, moduleId));  
         history.push(spreadsheetPageUrl(projectId, branch.id, datasetId));
     }


### PR DESCRIPTION
- dataset view in each cell now displays the dataset name, not id
- feature added: new cell recommendations can now be made
-- load cell recommendation for an empty notebook moved to the front end
-- unload recommended incase dataset size greater than allowed maximum (resolves #226)
- onEditSpreadsheet handle fixed

to be used with [web-api-async: 98](https://github.com/VizierDB/web-api-async/pull/98)